### PR TITLE
Update tags

### DIFF
--- a/guidelines/tag_guidelines.md
+++ b/guidelines/tag_guidelines.md
@@ -14,5 +14,5 @@ To make tag suggestions, please [create an issue](https://github.com/meilisearch
 - `meet-the-team`: series of interviews with Meilisearch employees
 - `release`: main changes introduced by new Meilisearch versions
 - `state-of-search`: search experience
-- `tech-tools`: tools that make our workflow easier
+- `engineering`: tehcnical content not related to using Meilisearch
 - `using-meilisearch`: tutorials, guides and posts about demos

--- a/guidelines/tag_guidelines.md
+++ b/guidelines/tag_guidelines.md
@@ -10,9 +10,9 @@ To make tag suggestions, please [create an issue](https://github.com/meilisearch
 
 - `community`: hacktoberfest, events, and community-related content
 - `company-news`: company announcements
+- `engineering`: tehcnical content not related to using Meilisearch
 - `future-of-work`: HR & employee experience
 - `meet-the-team`: series of interviews with Meilisearch employees
 - `release`: main changes introduced by new Meilisearch versions
 - `state-of-search`: search experience
-- `engineering`: tehcnical content not related to using Meilisearch
 - `using-meilisearch`: tutorials, guides and posts about demos


### PR DESCRIPTION
Replaces tech tools with engineering

# Pull Request

## Related issue
Fixes #536 

## What does this PR do?
- Deletes the `tech-tools` tag and add an `engineering` tag

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
